### PR TITLE
Fast seek changes

### DIFF
--- a/android/src/main/java/com/stellarscript/vlcvideo/VLCVideoView.java
+++ b/android/src/main/java/com/stellarscript/vlcvideo/VLCVideoView.java
@@ -276,6 +276,7 @@ public final class VLCVideoView extends SurfaceView {
 
     public void seek(final long time) {
         requestSeek(time);
+        mMediaPlayer.play();
         mMediaPlayer.setTime(time);
     }
 

--- a/android/src/main/java/com/stellarscript/vlcvideo/VLCVideoView.java
+++ b/android/src/main/java/com/stellarscript/vlcvideo/VLCVideoView.java
@@ -70,7 +70,7 @@ public final class VLCVideoView extends SurfaceView {
                     case KEYCODE_MEDIA_REWIND:
                         if (mMediaPlayer.isSeekable()) {
                             final int multiplier = keyCode == KEYCODE_MEDIA_REWIND ? -1 : 1;
-                            final long seekTime = Math.max(Math.min(mMediaPlayer.getTime() + (multiplier * D_PAD_SEEK_TIME), mMediaPlayer.getLength()-1000), 0);
+                            final long seekTime = Math.max(Math.min(mMediaPlayer.getTime() + (multiplier * D_PAD_SEEK_TIME), mMediaPlayer.getLength() - 1000), 0);
                             VLCVideoView.this.seek(seekTime);
                         }
                         return true;
@@ -276,8 +276,8 @@ public final class VLCVideoView extends SurfaceView {
 
     public void seek(final long time) {
         requestSeek(time);
-        mMediaPlayer.play();
         mMediaPlayer.setTime(time);
+        mMediaPlayer.play();
     }
 
     public boolean isPlaying() {
@@ -292,7 +292,9 @@ public final class VLCVideoView extends SurfaceView {
         return mMediaPlayer.getTime();
     }
 
-    public long getDuration() { return mMediaPlayer.getLength(); }
+    public long getDuration() {
+        return mMediaPlayer.getLength();
+    }
 
     private void stop() {
         mIsSeekRequested = false;

--- a/android/src/main/java/com/stellarscript/vlcvideo/VLCVideoView.java
+++ b/android/src/main/java/com/stellarscript/vlcvideo/VLCVideoView.java
@@ -71,7 +71,6 @@ public final class VLCVideoView extends SurfaceView {
                         if (mMediaPlayer.isSeekable()) {
                             final int multiplier = keyCode == KEYCODE_MEDIA_REWIND ? -1 : 1;
                             final long seekTime = Math.max(Math.min(mMediaPlayer.getTime() + (multiplier * D_PAD_SEEK_TIME), mMediaPlayer.getLength()-1000), 0);
-                            VLCVideoView.this.requestSeek(seekTime);
                             VLCVideoView.this.seek(seekTime);
                         }
                         return true;
@@ -276,6 +275,7 @@ public final class VLCVideoView extends SurfaceView {
     }
 
     public void seek(final long time) {
+        requestSeek(time);
         mMediaPlayer.setTime(time);
     }
 

--- a/android/src/main/java/com/stellarscript/vlcvideo/VLCVideoView.java
+++ b/android/src/main/java/com/stellarscript/vlcvideo/VLCVideoView.java
@@ -70,7 +70,8 @@ public final class VLCVideoView extends SurfaceView {
                     case KEYCODE_MEDIA_REWIND:
                         if (mMediaPlayer.isSeekable()) {
                             final int multiplier = keyCode == KEYCODE_MEDIA_REWIND ? -1 : 1;
-                            final long seekTime = Math.max(mMediaPlayer.getTime() + (multiplier * D_PAD_SEEK_TIME), 0);
+                            final long seekTime = Math.max(Math.min(mMediaPlayer.getTime() + (multiplier * D_PAD_SEEK_TIME), mMediaPlayer.getLength()-1000), 0);
+                            VLCVideoView.this.requestSeek(seekTime);
                             VLCVideoView.this.seek(seekTime);
                         }
                         return true;
@@ -269,11 +270,13 @@ public final class VLCVideoView extends SurfaceView {
         mMediaPlayer.pause();
     }
 
-    public void seek(final long time) {
+    public void requestSeek(final long time) {
         mIsSeekRequested = true;
         mEventEmitter.emitOnSeekRequested(time);
+    }
+
+    public void seek(final long time) {
         mMediaPlayer.setTime(time);
-        mMediaPlayer.play();
     }
 
     public boolean isPlaying() {
@@ -287,6 +290,8 @@ public final class VLCVideoView extends SurfaceView {
     public long getTime() {
         return mMediaPlayer.getTime();
     }
+
+    public long getDuration() { return mMediaPlayer.getLength(); }
 
     private void stop() {
         mIsSeekRequested = false;


### PR DESCRIPTION
Changes required for fast seek.
1. Added `getDuration` method
2. Splited `seek(long)` into `requestSeek(long)` and 'seek(long`)