### PR TITLE
Android TV - Long Press to Seek

### DIFF
--- a/android/src/main/java/com/stremio/vlcvideo/VLCVideoView.java
+++ b/android/src/main/java/com/stremio/vlcvideo/VLCVideoView.java
@@ -55,15 +55,21 @@ public final class VLCVideoView extends SurfaceView {
         @Override
         public boolean onKeyDown(final int keyCode, final KeyEvent keyEvent) {
             final int action = keyEvent.getAction();
-            if (action == ACTION_DOWN) {
+            final int repeatCount = keyEvent.getRepeatCount();
+            if (action == ACTION_DOWN && repeatCount % 4 == 0) {
                 switch (keyCode) {
                     case KEYCODE_SPACE:
                     case KEYCODE_MEDIA_PLAY_PAUSE:
+                        if (repeatCount > 0) {
+                            return false;
+                        }
+
                         if (mMediaPlayer.isPlaying()) {
                             mMediaPlayer.pause();
                         } else {
                             mMediaPlayer.play();
                         }
+
                         return true;
                     case KEYCODE_MEDIA_FAST_FORWARD:
                     case KEYCODE_MEDIA_REWIND:

--- a/android/src/main/java/com/stremio/vlcvideo/VLCVideoView.java
+++ b/android/src/main/java/com/stremio/vlcvideo/VLCVideoView.java
@@ -37,7 +37,7 @@ public final class VLCVideoView extends SurfaceView {
     private static final String PAUSE_ICON_RESOURCE_NAME = "react_native_vlc2_pause_icon";
     private static final String PLAY_INTENT_ACTION = "VLCVideo:Play";
     private static final String PAUSE_INTENT_ACTION = "VLCVideo:Pause";
-    private static final int D_PAD_SEEK_TIME = 30000;
+    private static final int D_PAD_SEEK_TIME = 15000;
 
     public static final int PLAYBACK_NOTIFICATION_ID = 11740;
 


### PR DESCRIPTION
This is one of 2 PRs (the other one will be in `stremio-rn`) that adds support for long pressing left / right / rewind / fast forward to seek, while also supporting spamming these buttons to seek.

I've already tested this on Android TV and it seems to work well.